### PR TITLE
perf: LP write speed improvements (misc)

### DIFF
--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -632,11 +632,7 @@ class Constraint:
         short = filter_nulls_polars(short)
         check_has_nulls_polars(short, name=f"{self.type} {self.name}")
 
-        df = pl.concat([short, long], how="diagonal_relaxed").sort(["labels", "rhs"])
-        # delete subsequent non-null rhs (happens is all vars per label are -1)
-        is_non_null = df["rhs"].is_not_null()
-        prev_non_is_null = is_non_null.shift(1).fill_null(False)
-        df = df.filter(is_non_null & ~prev_non_is_null | ~is_non_null)
+        df = long.join(short, on="labels", how="inner")
         return df[["labels", "coeffs", "vars", "sign", "rhs"]]
 
     # Wrapped function which would convert variable to dataarray

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -634,7 +634,7 @@ class Constraint:
 
         sign_values = ds["sign"].values
         sign_flat = np.broadcast_to(sign_values, ds["labels"].shape).reshape(-1)
-        all_same_sign = (
+        all_same_sign = len(sign_flat) > 0 and (
             sign_flat[0] == sign_flat[-1] and (sign_flat[0] == sign_flat).all()
         )
 

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1463,7 +1463,13 @@ class LinearExpression(BaseExpression):
 
         df = to_polars(self.data)
         df = filter_nulls_polars(df)
-        df = group_terms_polars(df)
+        if df["vars"].n_unique() < df.height:
+            df = group_terms_polars(df)
+        else:
+            # Match column order of group_terms (group-by keys, coeffs, rest)
+            varcols = [c for c in df.columns if c.startswith("vars")]
+            rest = [c for c in df.columns if c not in varcols and c != "coeffs"]
+            df = df.select(varcols + ["coeffs"] + rest)
         check_has_nulls_polars(df, name=self.type)
         return df
 

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -465,6 +465,7 @@ def constraints_to_file(
                 *signed_number(pl.col("coeffs")),
                 col_labels[0],
                 col_labels[1],
+                pl.when(pl.col("is_last_in_group")).then(pl.lit("\n")),
                 pl.when(pl.col("is_last_in_group")).then(pl.col("sign")),
                 pl.when(pl.col("is_last_in_group")).then(pl.lit(" ")),
                 pl.when(pl.col("is_last_in_group")).then(pl.col("rhs").cast(pl.String)),

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -446,48 +446,25 @@ def constraints_to_file(
             if df.height == 0:
                 continue
 
-            # Ensure each constraint has both coefficient and RHS terms
-            analysis = df.group_by("labels").agg(
-                [
-                    pl.col("coeffs").is_not_null().sum().alias("coeff_rows"),
-                    pl.col("sign").is_not_null().sum().alias("rhs_rows"),
-                ]
-            )
-
-            valid = analysis.filter(
-                (pl.col("coeff_rows") > 0) & (pl.col("rhs_rows") > 0)
-            )
-
-            if valid.height == 0:
-                continue
-
-            # Keep only constraints that have both parts
-            df = df.join(valid.select("labels"), on="labels", how="inner")
-
             # Sort by labels and mark first/last occurrences
             df = df.sort("labels").with_columns(
                 [
-                    pl.when(pl.col("labels").is_first_distinct())
-                    .then(pl.col("labels"))
-                    .otherwise(pl.lit(None))
-                    .alias("labels_first"),
+                    pl.col("labels").is_first_distinct().alias("is_first_in_group"),
                     (pl.col("labels") != pl.col("labels").shift(-1))
                     .fill_null(True)
                     .alias("is_last_in_group"),
                 ]
             )
 
-            row_labels = print_constraint(pl.col("labels_first"))
+            row_labels = print_constraint(pl.col("labels"))
             col_labels = print_variable(pl.col("vars"))
             columns = [
-                pl.when(pl.col("labels_first").is_not_null()).then(row_labels[0]),
-                pl.when(pl.col("labels_first").is_not_null()).then(row_labels[1]),
-                pl.when(pl.col("labels_first").is_not_null())
-                .then(pl.lit(":\n"))
-                .alias(":"),
+                pl.when(pl.col("is_first_in_group")).then(row_labels[0]),
+                pl.when(pl.col("is_first_in_group")).then(row_labels[1]),
+                pl.when(pl.col("is_first_in_group")).then(pl.lit(":\n")).alias(":"),
                 *signed_number(pl.col("coeffs")),
-                pl.when(pl.col("vars").is_not_null()).then(col_labels[0]),
-                pl.when(pl.col("vars").is_not_null()).then(col_labels[1]),
+                col_labels[0],
+                col_labels[1],
                 pl.when(pl.col("is_last_in_group")).then(pl.col("sign")),
                 pl.when(pl.col("is_last_in_group")).then(pl.lit(" ")),
                 pl.when(pl.col("is_last_in_group")).then(pl.col("rhs").cast(pl.String)),


### PR DESCRIPTION
## Summary
- Replace `concat+sort` with `join` for constraint writing in `io.py` and `constraints.py`
- Fix missing space in LP file output
- Skip `group_terms` when unnecessary in `Constraint.to_polars()` and `LinearExpression.to_polars()`
- Reduce per-constraint overhead by applying labels mask directly and using fast sign uniformity check
- Fix `IndexError` on empty constraint slices in `sign_flat` check

**Note:** This PR targets `perf/polars-streaming` (#563 on PyPSA/linopy). Retarget to `master` after that merges.

## Benchmarks (additional speedup on top of PR1)

| Benchmark | PR1 | PR1+PR2 | Extra speedup |
|---|---|---|---|
| basic N=500 (500K vars) | 704ms | 361ms | 1.9x |
| basic N=1000 (2M vars) | 2830ms | 1382ms | 2.0x |
| knapsack 100K | 57ms | 45ms | 1.3x |
| PyPSA 24 snapshots (60K vars) | 438ms | 260ms | 1.7x |
| PyPSA 100 snapshots (249K vars) | 1278ms | 565ms | 2.3x |
| PyPSA 500 snapshots (1.2M vars) | 4428ms | 2125ms | 2.1x |

**Combined speedup vs master: 2.0-2.7x on large models.**

## Commits
1. `perf: replace concat+sort with join` (io.py, constraints.py)
2. `fix: missing space in lp file` (io.py)
3. `perf: skip group_terms when unnecessary` (constraints.py)
4. `perf: skip group_terms in LinearExpression.to_polars` (expressions.py)
5. `perf: reduce per-constraint overhead` (constraints.py)
6. `fix: handle empty constraint slices in sign_flat check` (constraints.py)

## Test plan
- [x] `pytest test/test_io.py` passes (21/21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)