### PR TITLE
feat: add discontinuous piecewise linear constraints

### DIFF
--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -36,11 +36,19 @@ sign_replace_dict: dict[str, str] = {
 TERM_DIM = "_term"
 STACKED_TERM_DIM = "_stacked_term"
 
-# Piecewise linear constraint constants
+# Piecewise linear constraint constants (continuous - SOS2)
 PWL_LAMBDA_SUFFIX = "_lambda"
 PWL_CONVEX_SUFFIX = "_convex"
 PWL_LINK_SUFFIX = "_link"
 DEFAULT_BREAKPOINT_DIM = "breakpoint"
+
+# Discontinuous piecewise linear constraint constants (binary formulation)
+DPWL_BINARY_SUFFIX = "_binary"
+DPWL_DELTA_SUFFIX = "_delta"
+DPWL_SELECT_SUFFIX = "_select"
+DPWL_DELTA_BOUND_SUFFIX = "_delta_bound"
+DPWL_LINK_SUFFIX = "_link"
+DEFAULT_PIECE_DIM = "piece"
 GROUPED_TERM_DIM = "_grouped_term"
 GROUP_DIM = "_group"
 FACTOR_DIM = "_factor"

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -36,6 +36,12 @@ from linopy.common import (
 )
 from linopy.constants import (
     DEFAULT_BREAKPOINT_DIM,
+    DEFAULT_PIECE_DIM,
+    DPWL_BINARY_SUFFIX,
+    DPWL_DELTA_BOUND_SUFFIX,
+    DPWL_DELTA_SUFFIX,
+    DPWL_LINK_SUFFIX,
+    DPWL_SELECT_SUFFIX,
     GREATER_EQUAL,
     HELPER_DIMS,
     LESS_EQUAL,
@@ -135,6 +141,7 @@ class Model:
         "_varnameCounter",
         "_connameCounter",
         "_pwlCounter",
+        "_dpwlCounter",
         "_blocks",
         # TODO: check if these should not be mutable
         "_chunk",
@@ -186,6 +193,7 @@ class Model:
         self._varnameCounter: int = 0
         self._connameCounter: int = 0
         self._pwlCounter: int = 0
+        self._dpwlCounter: int = 0
         self._blocks: DataArray | None = None
 
         self._chunk: T_Chunks = chunk
@@ -862,6 +870,238 @@ class Model:
         # Concatenate along link_dim
         stacked_data = xr.concat(expr_data_list, dim=link_dim)
         return LinearExpression(stacked_data, self)
+
+    def add_discontinuous_piecewise_constraints(
+        self,
+        expr: Variable | LinearExpression | dict[str, Variable | LinearExpression],
+        piece_starts: DataArray,
+        piece_ends: DataArray,
+        link_dim: str | None = None,
+        dim: str = DEFAULT_PIECE_DIM,
+        mask: DataArray | None = None,
+        name: str | None = None,
+        skip_nan_check: bool = False,
+    ) -> Constraint:
+        """
+        Add discontinuous piecewise linear constraints using binary formulation.
+
+        Creates constraints linking expressions through a piecewise linear function
+        that may have gaps or discontinuities between pieces. Uses binary variables
+        to select which piece is active.
+
+        Parameters
+        ----------
+        expr : Variable | LinearExpression | dict[str, Variable | LinearExpression]
+            The expression(s) to constrain. Can be:
+            - A single Variable or LinearExpression
+            - A dict mapping names to Variables/Expressions (for linked quantities)
+        piece_starts : DataArray
+            Values at the start of each piece. Must have the `dim` dimension.
+            For dict expr, must also have `link_dim` dimension matching dict keys.
+        piece_ends : DataArray
+            Values at the end of each piece. Must have same dimensions as piece_starts.
+        link_dim : str, optional
+            Dimension in piece_starts/piece_ends whose coordinates match dict keys.
+            Auto-detected if not provided when expr is a dict.
+        dim : str, default "piece"
+            Name of the piece dimension in piece_starts and piece_ends.
+        mask : DataArray, optional
+            Boolean mask indicating which pieces are valid. If None and
+            skip_nan_check is False, mask is computed from non-NaN values.
+        name : str, optional
+            Base name for generated variables and constraints. Auto-generated
+            as "dpwl0", "dpwl1", etc. if not provided.
+        skip_nan_check : bool, default False
+            If True, skip automatic NaN detection for mask computation.
+            Use when pieces contain no NaN values for better performance.
+
+        Returns
+        -------
+        Constraint
+            The piece selection constraint (sum of binary variables = 1).
+
+        Raises
+        ------
+        ValueError
+            If expr is not a Variable, LinearExpression, or dict of these.
+            If piece_starts/piece_ends don't have the required dim dimension.
+            If piece_starts and piece_ends have different dimensions.
+            If link_dim cannot be auto-detected when expr is a dict.
+            If link_dim coordinates don't match dict keys.
+
+        Examples
+        --------
+        Single variable with discontinuous pieces (gaps between pieces):
+
+        >>> m = Model()
+        >>> x = m.add_variables(name="x")
+        >>> starts = xr.DataArray([0, 15, 30], dims=["piece"])
+        >>> ends = xr.DataArray([10, 25, 50], dims=["piece"])
+        >>> _ = m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+        Multiple linked variables (e.g., power-cost curve with operating regions):
+
+        >>> m = Model()
+        >>> power = m.add_variables(name="power")
+        >>> cost = m.add_variables(name="cost")
+        >>> starts = xr.DataArray(
+        ...     [[0, 60], [0, 150]],
+        ...     dims=["var", "piece"],
+        ...     coords={"var": ["power", "cost"]},
+        ... )
+        >>> ends = xr.DataArray(
+        ...     [[50, 100], [100, 300]],
+        ...     dims=["var", "piece"],
+        ...     coords={"var": ["power", "cost"]},
+        ... )
+        >>> _ = m.add_discontinuous_piecewise_constraints(
+        ...     {"power": power, "cost": cost},
+        ...     starts,
+        ...     ends,
+        ...     link_dim="var",
+        ...     dim="piece",
+        ... )
+
+        Notes
+        -----
+        The discontinuous piecewise linear constraint uses a binary formulation:
+
+        1. Binary variables y_i ∈ {0,1} for each piece i (is piece active?)
+        2. Delta variables δ_i ∈ [0,1] for interpolation within piece i
+        3. Selection constraint: Σ y_i = 1 (exactly one piece active)
+        4. Delta bound: δ_i ≤ y_i (delta only positive if piece active)
+        5. Linking: expr = Σ [start_i · y_i + (end_i - start_i) · δ_i]
+
+        Unlike add_piecewise_constraints (which uses SOS2), this method:
+        - Supports gaps between pieces
+        - Works with any MIP solver (no SOS2 support required)
+        - Uses binary variables (slower than SOS2 for continuous PWL)
+        """
+        # --- Input validation ---
+        if dim not in piece_starts.dims:
+            raise ValueError(
+                f"piece_starts must have dimension '{dim}', "
+                f"but only has dimensions {list(piece_starts.dims)}"
+            )
+        if dim not in piece_ends.dims:
+            raise ValueError(
+                f"piece_ends must have dimension '{dim}', "
+                f"but only has dimensions {list(piece_ends.dims)}"
+            )
+        if piece_starts.dims != piece_ends.dims:
+            raise ValueError(
+                f"piece_starts and piece_ends must have same dimensions. "
+                f"Got {list(piece_starts.dims)} and {list(piece_ends.dims)}"
+            )
+
+        # --- Generate names using counter ---
+        if name is None:
+            name = f"dpwl{self._dpwlCounter}"
+            self._dpwlCounter += 1
+
+        binary_name = f"{name}{DPWL_BINARY_SUFFIX}"
+        delta_name = f"{name}{DPWL_DELTA_SUFFIX}"
+        select_name = f"{name}{DPWL_SELECT_SUFFIX}"
+        delta_bound_name = f"{name}{DPWL_DELTA_BOUND_SUFFIX}"
+        link_name = f"{name}{DPWL_LINK_SUFFIX}"
+
+        # --- Determine variable coordinates, mask, and target expression ---
+        is_single = isinstance(expr, Variable | LinearExpression)
+        is_dict = isinstance(expr, dict)
+
+        if not is_single and not is_dict:
+            raise ValueError(
+                f"'expr' must be a Variable, LinearExpression, or dict of these, "
+                f"got {type(expr)}"
+            )
+
+        # Compute piece deltas (end - start)
+        piece_deltas = piece_ends - piece_starts
+
+        if is_single:
+            # Single expression case
+            target_expr = self._to_linexpr(expr)
+            # Build variable coordinates from piece dimensions
+            var_coords = [
+                pd.Index(piece_starts.coords[d].values, name=d)
+                for d in piece_starts.dims
+            ]
+            var_mask = self._compute_dpwl_mask(
+                mask, piece_starts, piece_ends, skip_nan_check
+            )
+            # For linking: use piece_starts and piece_deltas directly
+            link_starts = piece_starts
+            link_deltas = piece_deltas
+        else:
+            # Dict case - need to validate link_dim and build stacked expression
+            expr_dict = expr
+            expr_keys = set(expr_dict.keys())
+
+            # Auto-detect or validate link_dim (reuse helper from PWL)
+            link_dim = self._resolve_pwl_link_dim(
+                link_dim, piece_starts, dim, expr_keys
+            )
+
+            # Build variable coordinates (exclude link_dim)
+            var_coords = [
+                pd.Index(piece_starts.coords[d].values, name=d)
+                for d in piece_starts.dims
+                if d != link_dim
+            ]
+
+            # Compute mask (valid if ANY linked variable has valid piece)
+            base_mask = self._compute_dpwl_mask(
+                mask, piece_starts, piece_ends, skip_nan_check
+            )
+            var_mask = base_mask.any(dim=link_dim) if base_mask is not None else None
+
+            # Build stacked expression from dict
+            target_expr = self._build_stacked_expr(expr_dict, piece_starts, link_dim)
+
+            # For linking: use full piece_starts and piece_deltas (include link_dim)
+            link_starts = piece_starts
+            link_deltas = piece_deltas
+
+        # --- Create binary and delta variables ---
+        binary_var = self.add_variables(
+            coords=var_coords, name=binary_name, mask=var_mask, binary=True
+        )
+
+        delta_var = self.add_variables(
+            lower=0, upper=1, coords=var_coords, name=delta_name, mask=var_mask
+        )
+
+        # --- Add selection constraint: Σ y_i = 1 ---
+        select_con = self.add_constraints(
+            binary_var.sum(dim=dim) == 1, name=select_name
+        )
+
+        # --- Add delta bound constraint: δ_i ≤ y_i ---
+        self.add_constraints(delta_var <= binary_var, name=delta_bound_name)
+
+        # --- Add linking constraint ---
+        # expr = Σ [start_i · y_i + (end_i - start_i) · δ_i]
+        reconstructed = (link_starts * binary_var + link_deltas * delta_var).sum(
+            dim=dim
+        )
+        self.add_constraints(target_expr == reconstructed, name=link_name)
+
+        return select_con
+
+    def _compute_dpwl_mask(
+        self,
+        mask: DataArray | None,
+        piece_starts: DataArray,
+        piece_ends: DataArray,
+        skip_nan_check: bool,
+    ) -> DataArray | None:
+        """Compute mask for discontinuous PWL, optionally skipping NaN check."""
+        if mask is not None:
+            return mask
+        if skip_nan_check:
+            return None
+        # Piece is valid if both start and end are non-NaN
+        return ~piece_starts.isnull() & ~piece_ends.isnull()
 
     def add_constraints(
         self,

--- a/test/test_discontinuous_piecewise_constraints.py
+++ b/test/test_discontinuous_piecewise_constraints.py
@@ -1,18 +1,25 @@
-"""
-Tests for discontinuous piecewise linear constraints using binary formulation.
-"""
+"""Tests for discontinuous piecewise linear constraints using binary formulation."""
+
+from __future__ import annotations
 
 import numpy as np
 import pytest
 import xarray as xr
 
 from linopy import Model, available_solvers
+from linopy.constants import (
+    DPWL_BINARY_SUFFIX,
+    DPWL_DELTA_BOUND_SUFFIX,
+    DPWL_DELTA_SUFFIX,
+    DPWL_LINK_SUFFIX,
+    DPWL_SELECT_SUFFIX,
+)
 
 
 class TestBasicSingleVariable:
     """Tests for single variable discontinuous piecewise constraints."""
 
-    def test_basic_single_variable(self):
+    def test_basic_single_variable(self) -> None:
         """Test basic discontinuous PWL with a single variable."""
         m = Model()
         x = m.add_variables(name="x")
@@ -24,19 +31,19 @@ class TestBasicSingleVariable:
         con = m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
         # Check that variables and constraints were created
-        assert "dpwl0_binary" in m.variables
-        assert "dpwl0_delta" in m.variables
-        assert "dpwl0_select" in m.constraints
-        assert "dpwl0_delta_bound" in m.constraints
-        assert "dpwl0_link" in m.constraints
+        assert f"dpwl0{DPWL_BINARY_SUFFIX}" in m.variables
+        assert f"dpwl0{DPWL_DELTA_SUFFIX}" in m.variables
+        assert f"dpwl0{DPWL_SELECT_SUFFIX}" in m.constraints
+        assert f"dpwl0{DPWL_DELTA_BOUND_SUFFIX}" in m.constraints
+        assert f"dpwl0{DPWL_LINK_SUFFIX}" in m.constraints
 
         # Check binary variable is indeed binary
-        assert m.variables["dpwl0_binary"].attrs.get("binary", False)
+        assert m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].attrs.get("binary", False)
 
         # Check return value is the selection constraint
-        assert con.name == "dpwl0_select"
+        assert con.name == f"dpwl0{DPWL_SELECT_SUFFIX}"
 
-    def test_single_variable_with_coords(self):
+    def test_single_variable_with_coords(self) -> None:
         """Test single variable with explicit piece coordinates."""
         m = Model()
         x = m.add_variables(name="x")
@@ -51,7 +58,9 @@ class TestBasicSingleVariable:
         m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
         # Check coordinates are preserved
-        assert list(m.variables["dpwl0_binary"].coords["piece"].values) == [
+        assert list(
+            m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].coords["piece"].values
+        ) == [
             "low",
             "mid",
             "high",
@@ -61,7 +70,7 @@ class TestBasicSingleVariable:
 class TestDictOfVariables:
     """Tests for dict of variables (linked quantities)."""
 
-    def test_dict_of_variables(self):
+    def test_dict_of_variables(self) -> None:
         """Test discontinuous PWL with multiple linked variables."""
         m = Model()
         power = m.add_variables(name="power")
@@ -83,11 +92,11 @@ class TestDictOfVariables:
             {"power": power, "cost": cost}, starts, ends, link_dim="var", dim="piece"
         )
 
-        assert "dpwl0_binary" in m.variables
-        assert "dpwl0_delta" in m.variables
-        assert "dpwl0_link" in m.constraints
+        assert f"dpwl0{DPWL_BINARY_SUFFIX}" in m.variables
+        assert f"dpwl0{DPWL_DELTA_SUFFIX}" in m.variables
+        assert f"dpwl0{DPWL_LINK_SUFFIX}" in m.constraints
 
-    def test_dict_with_additional_coords(self):
+    def test_dict_with_additional_coords(self) -> None:
         """Test dict of variables with additional dimensions (e.g., generators)."""
         m = Model()
         generators = ["gen1", "gen2"]
@@ -117,13 +126,13 @@ class TestDictOfVariables:
         )
 
         # Binary/delta variables should have gen and piece dimensions (not var)
-        assert set(m.variables["dpwl0_binary"].dims) == {"gen", "piece"}
+        assert set(m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].dims) == {"gen", "piece"}
 
 
 class TestAutoDetectLinkDim:
     """Tests for auto-detection of link_dim."""
 
-    def test_auto_detect_link_dim(self):
+    def test_auto_detect_link_dim(self) -> None:
         """Test that link_dim is auto-detected from piece coordinates."""
         m = Model()
         x = m.add_variables(name="x")
@@ -145,9 +154,9 @@ class TestAutoDetectLinkDim:
             {"x": x, "y": y}, starts, ends, dim="piece"
         )
 
-        assert "dpwl0_binary" in m.variables
+        assert f"dpwl0{DPWL_BINARY_SUFFIX}" in m.variables
 
-    def test_auto_detect_fails_with_no_match(self):
+    def test_auto_detect_fails_with_no_match(self) -> None:
         """Test that auto-detection fails with helpful error when no match."""
         m = Model()
         x = m.add_variables(name="x")
@@ -173,7 +182,7 @@ class TestAutoDetectLinkDim:
 class TestMasking:
     """Tests for masking functionality."""
 
-    def test_nan_masking(self):
+    def test_nan_masking(self) -> None:
         """Test that NaN values in pieces create masked variables."""
         m = Model()
         x = m.add_variables(name="x")
@@ -185,12 +194,12 @@ class TestMasking:
         m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
         # Check that binary variable has only 2 valid entries
-        binary_labels = m.variables["dpwl0_binary"].labels
+        binary_labels = m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].labels
         assert binary_labels.isel(piece=0).item() != -1
         assert binary_labels.isel(piece=1).item() != -1
         assert binary_labels.isel(piece=2).item() == -1
 
-    def test_nan_masking_partial(self):
+    def test_nan_masking_partial(self) -> None:
         """Test that piece is invalid if EITHER start OR end is NaN."""
         m = Model()
         x = m.add_variables(name="x")
@@ -201,12 +210,12 @@ class TestMasking:
 
         m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
-        binary_labels = m.variables["dpwl0_binary"].labels
+        binary_labels = m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].labels
         assert binary_labels.isel(piece=0).item() != -1  # valid
         assert binary_labels.isel(piece=1).item() == -1  # invalid (NaN end)
         assert binary_labels.isel(piece=2).item() == -1  # invalid (NaN start)
 
-    def test_explicit_mask(self):
+    def test_explicit_mask(self) -> None:
         """Test that explicit mask parameter works."""
         m = Model()
         x = m.add_variables(name="x")
@@ -219,12 +228,12 @@ class TestMasking:
             x, starts, ends, dim="piece", mask=mask
         )
 
-        binary_labels = m.variables["dpwl0_binary"].labels
+        binary_labels = m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].labels
         assert binary_labels.isel(piece=0).item() != -1
         assert binary_labels.isel(piece=1).item() == -1  # masked out
         assert binary_labels.isel(piece=2).item() != -1
 
-    def test_skip_nan_check(self):
+    def test_skip_nan_check(self) -> None:
         """Test that skip_nan_check bypasses NaN detection."""
         m = Model()
         x = m.add_variables(name="x")
@@ -238,7 +247,7 @@ class TestMasking:
         )
 
         # All pieces should be created (no mask applied)
-        binary_labels = m.variables["dpwl0_binary"].labels
+        binary_labels = m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].labels
         assert binary_labels.isel(piece=0).item() != -1
         assert binary_labels.isel(piece=1).item() != -1
         assert binary_labels.isel(piece=2).item() != -1
@@ -247,7 +256,7 @@ class TestMasking:
 class TestMultiDimensional:
     """Tests for multi-dimensional cases."""
 
-    def test_multi_dimensional_pieces(self):
+    def test_multi_dimensional_pieces(self) -> None:
         """Test with pieces that vary across another dimension."""
         m = Model()
         generators = ["gen1", "gen2"]
@@ -268,14 +277,14 @@ class TestMultiDimensional:
         m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
         # Variables should have both gen and piece dimensions
-        assert set(m.variables["dpwl0_binary"].dims) == {"gen", "piece"}
-        assert set(m.variables["dpwl0_delta"].dims) == {"gen", "piece"}
+        assert set(m.variables[f"dpwl0{DPWL_BINARY_SUFFIX}"].dims) == {"gen", "piece"}
+        assert set(m.variables[f"dpwl0{DPWL_DELTA_SUFFIX}"].dims) == {"gen", "piece"}
 
 
 class TestValidationErrors:
     """Tests for input validation error handling."""
 
-    def test_invalid_expr_type(self):
+    def test_invalid_expr_type(self) -> None:
         """Test that invalid expr type raises ValueError."""
         m = Model()
 
@@ -287,7 +296,7 @@ class TestValidationErrors:
                 "invalid", starts, ends, dim="piece"
             )
 
-    def test_missing_dim_in_starts(self):
+    def test_missing_dim_in_starts(self) -> None:
         """Test error when dim is missing from piece_starts."""
         m = Model()
         x = m.add_variables(name="x")
@@ -298,7 +307,7 @@ class TestValidationErrors:
         with pytest.raises(ValueError, match="piece_starts must have dimension"):
             m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
-    def test_missing_dim_in_ends(self):
+    def test_missing_dim_in_ends(self) -> None:
         """Test error when dim is missing from piece_ends."""
         m = Model()
         x = m.add_variables(name="x")
@@ -309,7 +318,7 @@ class TestValidationErrors:
         with pytest.raises(ValueError, match="piece_ends must have dimension"):
             m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
-    def test_mismatched_dimensions(self):
+    def test_mismatched_dimensions(self) -> None:
         """Test error when starts and ends have different dimensions."""
         m = Model()
         x = m.add_variables(name="x")
@@ -320,7 +329,7 @@ class TestValidationErrors:
         with pytest.raises(ValueError, match="must have same dimensions"):
             m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
-    def test_expression_support(self):
+    def test_expression_support(self) -> None:
         """Test that LinearExpression is supported as input."""
         m = Model()
         x = m.add_variables(name="x")
@@ -332,9 +341,9 @@ class TestValidationErrors:
         # Should not raise
         m.add_discontinuous_piecewise_constraints(x + y, starts, ends, dim="piece")
 
-        assert "dpwl0_link" in m.constraints
+        assert f"dpwl0{DPWL_LINK_SUFFIX}" in m.constraints
 
-    def test_link_dim_not_in_pieces(self):
+    def test_link_dim_not_in_pieces(self) -> None:
         """Test error when link_dim is not in piece arrays."""
         m = Model()
         x = m.add_variables(name="x")
@@ -348,7 +357,7 @@ class TestValidationErrors:
                 {"x": x, "y": y}, starts, ends, link_dim="var", dim="piece"
             )
 
-    def test_link_dim_coords_mismatch(self):
+    def test_link_dim_coords_mismatch(self) -> None:
         """Test error when link_dim coords don't match dict keys."""
         m = Model()
         x = m.add_variables(name="x")
@@ -374,7 +383,7 @@ class TestValidationErrors:
 class TestNameGeneration:
     """Tests for automatic name generation."""
 
-    def test_auto_name_generation(self):
+    def test_auto_name_generation(self) -> None:
         """Test that names are auto-generated with counter."""
         m = Model()
         x = m.add_variables(name="x")
@@ -385,10 +394,10 @@ class TestNameGeneration:
         m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
         m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
 
-        assert "dpwl0_binary" in m.variables
-        assert "dpwl1_binary" in m.variables
+        assert f"dpwl0{DPWL_BINARY_SUFFIX}" in m.variables
+        assert f"dpwl1{DPWL_BINARY_SUFFIX}" in m.variables
 
-    def test_custom_name(self):
+    def test_custom_name(self) -> None:
         """Test that custom name parameter works."""
         m = Model()
         x = m.add_variables(name="x")
@@ -400,19 +409,19 @@ class TestNameGeneration:
             x, starts, ends, dim="piece", name="my_dpwl"
         )
 
-        assert "my_dpwl_binary" in m.variables
-        assert "my_dpwl_delta" in m.variables
-        assert "my_dpwl_select" in m.constraints
+        assert f"my_dpwl{DPWL_BINARY_SUFFIX}" in m.variables
+        assert f"my_dpwl{DPWL_DELTA_SUFFIX}" in m.variables
+        assert f"my_dpwl{DPWL_SELECT_SUFFIX}" in m.constraints
 
 
 class TestSolverIntegration:
     """Integration tests with actual solver (requires Gurobi, CPLEX, or HiGHS)."""
 
     @pytest.mark.parametrize(
-        "solver,module",
+        ("solver", "module"),
         [("gurobi", "gurobipy"), ("cplex", "cplex"), ("highs", "highspy")],
     )
-    def test_solve_single_variable_gap(self, solver, module):
+    def test_solve_single_variable_gap(self, solver: str, module: str) -> None:
         """Test solving with a gap - should find optimum in valid region."""
         if solver not in available_solvers:
             pytest.skip(f"{solver} not available")
@@ -435,10 +444,10 @@ class TestSolverIntegration:
         assert np.isclose(m.solution["x"].item(), 30.0, atol=1e-5)
 
     @pytest.mark.parametrize(
-        "solver,module",
+        ("solver", "module"),
         [("gurobi", "gurobipy"), ("cplex", "cplex"), ("highs", "highspy")],
     )
-    def test_solve_finds_correct_piece(self, solver, module):
+    def test_solve_finds_correct_piece(self, solver: str, module: str) -> None:
         """Test that solver correctly selects the optimal piece."""
         if solver not in available_solvers:
             pytest.skip(f"{solver} not available")
@@ -474,10 +483,10 @@ class TestSolverIntegration:
         assert np.isclose(m.solution["x"].item(), 30.0, atol=1e-5)
 
     @pytest.mark.parametrize(
-        "solver,module",
+        ("solver", "module"),
         [("gurobi", "gurobipy"), ("cplex", "cplex"), ("highs", "highspy")],
     )
-    def test_solve_step_function(self, solver, module):
+    def test_solve_step_function(self, solver: str, module: str) -> None:
         """Test solving with a step function (discontinuity in y)."""
         if solver not in available_solvers:
             pytest.skip(f"{solver} not available")

--- a/test/test_discontinuous_piecewise_constraints.py
+++ b/test/test_discontinuous_piecewise_constraints.py
@@ -1,0 +1,512 @@
+"""
+Tests for discontinuous piecewise linear constraints using binary formulation.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from linopy import Model, available_solvers
+
+
+class TestBasicSingleVariable:
+    """Tests for single variable discontinuous piecewise constraints."""
+
+    def test_basic_single_variable(self):
+        """Test basic discontinuous PWL with a single variable."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        # 3 pieces with gaps: [0,10], [15,25], [30,50]
+        starts = xr.DataArray([0, 15, 30], dims=["piece"])
+        ends = xr.DataArray([10, 25, 50], dims=["piece"])
+
+        con = m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+        # Check that variables and constraints were created
+        assert "dpwl0_binary" in m.variables
+        assert "dpwl0_delta" in m.variables
+        assert "dpwl0_select" in m.constraints
+        assert "dpwl0_delta_bound" in m.constraints
+        assert "dpwl0_link" in m.constraints
+
+        # Check binary variable is indeed binary
+        assert m.variables["dpwl0_binary"].attrs.get("binary", False)
+
+        # Check return value is the selection constraint
+        assert con.name == "dpwl0_select"
+
+    def test_single_variable_with_coords(self):
+        """Test single variable with explicit piece coordinates."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        starts = xr.DataArray(
+            [0, 15, 30], dims=["piece"], coords={"piece": ["low", "mid", "high"]}
+        )
+        ends = xr.DataArray(
+            [10, 25, 50], dims=["piece"], coords={"piece": ["low", "mid", "high"]}
+        )
+
+        m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+        # Check coordinates are preserved
+        assert list(m.variables["dpwl0_binary"].coords["piece"].values) == [
+            "low",
+            "mid",
+            "high",
+        ]
+
+
+class TestDictOfVariables:
+    """Tests for dict of variables (linked quantities)."""
+
+    def test_dict_of_variables(self):
+        """Test discontinuous PWL with multiple linked variables."""
+        m = Model()
+        power = m.add_variables(name="power")
+        cost = m.add_variables(name="cost")
+
+        # Two operating regions with a gap
+        starts = xr.DataArray(
+            [[0, 60], [0, 150]],
+            dims=["var", "piece"],
+            coords={"var": ["power", "cost"]},
+        )
+        ends = xr.DataArray(
+            [[50, 100], [100, 300]],
+            dims=["var", "piece"],
+            coords={"var": ["power", "cost"]},
+        )
+
+        m.add_discontinuous_piecewise_constraints(
+            {"power": power, "cost": cost}, starts, ends, link_dim="var", dim="piece"
+        )
+
+        assert "dpwl0_binary" in m.variables
+        assert "dpwl0_delta" in m.variables
+        assert "dpwl0_link" in m.constraints
+
+    def test_dict_with_additional_coords(self):
+        """Test dict of variables with additional dimensions (e.g., generators)."""
+        m = Model()
+        generators = ["gen1", "gen2"]
+        power = m.add_variables(coords=[generators], name="power")
+        cost = m.add_variables(coords=[generators], name="cost")
+
+        # Different pieces per generator
+        starts = xr.DataArray(
+            [
+                [[0, 60], [0, 150]],  # gen1
+                [[0, 40], [0, 80]],  # gen2
+            ],
+            dims=["gen", "var", "piece"],
+            coords={"gen": generators, "var": ["power", "cost"]},
+        )
+        ends = xr.DataArray(
+            [
+                [[50, 100], [100, 300]],  # gen1
+                [[30, 70], [60, 200]],  # gen2
+            ],
+            dims=["gen", "var", "piece"],
+            coords={"gen": generators, "var": ["power", "cost"]},
+        )
+
+        m.add_discontinuous_piecewise_constraints(
+            {"power": power, "cost": cost}, starts, ends, link_dim="var", dim="piece"
+        )
+
+        # Binary/delta variables should have gen and piece dimensions (not var)
+        assert set(m.variables["dpwl0_binary"].dims) == {"gen", "piece"}
+
+
+class TestAutoDetectLinkDim:
+    """Tests for auto-detection of link_dim."""
+
+    def test_auto_detect_link_dim(self):
+        """Test that link_dim is auto-detected from piece coordinates."""
+        m = Model()
+        x = m.add_variables(name="x")
+        y = m.add_variables(name="y")
+
+        starts = xr.DataArray(
+            [[0, 15], [0, 20]],
+            dims=["var", "piece"],
+            coords={"var": ["x", "y"]},
+        )
+        ends = xr.DataArray(
+            [[10, 25], [15, 30]],
+            dims=["var", "piece"],
+            coords={"var": ["x", "y"]},
+        )
+
+        # Should auto-detect link_dim="var" from coordinates matching dict keys
+        m.add_discontinuous_piecewise_constraints(
+            {"x": x, "y": y}, starts, ends, dim="piece"
+        )
+
+        assert "dpwl0_binary" in m.variables
+
+    def test_auto_detect_fails_with_no_match(self):
+        """Test that auto-detection fails with helpful error when no match."""
+        m = Model()
+        x = m.add_variables(name="x")
+        y = m.add_variables(name="y")
+
+        starts = xr.DataArray(
+            [[0, 15], [0, 20]],
+            dims=["other", "piece"],
+            coords={"other": ["a", "b"]},  # doesn't match dict keys
+        )
+        ends = xr.DataArray(
+            [[10, 25], [15, 30]],
+            dims=["other", "piece"],
+            coords={"other": ["a", "b"]},
+        )
+
+        with pytest.raises(ValueError, match="Could not auto-detect link_dim"):
+            m.add_discontinuous_piecewise_constraints(
+                {"x": x, "y": y}, starts, ends, dim="piece"
+            )
+
+
+class TestMasking:
+    """Tests for masking functionality."""
+
+    def test_nan_masking(self):
+        """Test that NaN values in pieces create masked variables."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        # Third piece is invalid (NaN)
+        starts = xr.DataArray([0, 15, np.nan], dims=["piece"])
+        ends = xr.DataArray([10, 25, np.nan], dims=["piece"])
+
+        m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+        # Check that binary variable has only 2 valid entries
+        binary_labels = m.variables["dpwl0_binary"].labels
+        assert binary_labels.isel(piece=0).item() != -1
+        assert binary_labels.isel(piece=1).item() != -1
+        assert binary_labels.isel(piece=2).item() == -1
+
+    def test_nan_masking_partial(self):
+        """Test that piece is invalid if EITHER start OR end is NaN."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        # Second piece has NaN end, third piece has NaN start
+        starts = xr.DataArray([0, 15, np.nan], dims=["piece"])
+        ends = xr.DataArray([10, np.nan, 50], dims=["piece"])
+
+        m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+        binary_labels = m.variables["dpwl0_binary"].labels
+        assert binary_labels.isel(piece=0).item() != -1  # valid
+        assert binary_labels.isel(piece=1).item() == -1  # invalid (NaN end)
+        assert binary_labels.isel(piece=2).item() == -1  # invalid (NaN start)
+
+    def test_explicit_mask(self):
+        """Test that explicit mask parameter works."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        starts = xr.DataArray([0, 15, 30], dims=["piece"])
+        ends = xr.DataArray([10, 25, 50], dims=["piece"])
+        mask = xr.DataArray([True, False, True], dims=["piece"])
+
+        m.add_discontinuous_piecewise_constraints(
+            x, starts, ends, dim="piece", mask=mask
+        )
+
+        binary_labels = m.variables["dpwl0_binary"].labels
+        assert binary_labels.isel(piece=0).item() != -1
+        assert binary_labels.isel(piece=1).item() == -1  # masked out
+        assert binary_labels.isel(piece=2).item() != -1
+
+    def test_skip_nan_check(self):
+        """Test that skip_nan_check bypasses NaN detection."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        # Has NaN but we skip the check
+        starts = xr.DataArray([0, 15, np.nan], dims=["piece"])
+        ends = xr.DataArray([10, 25, np.nan], dims=["piece"])
+
+        m.add_discontinuous_piecewise_constraints(
+            x, starts, ends, dim="piece", skip_nan_check=True
+        )
+
+        # All pieces should be created (no mask applied)
+        binary_labels = m.variables["dpwl0_binary"].labels
+        assert binary_labels.isel(piece=0).item() != -1
+        assert binary_labels.isel(piece=1).item() != -1
+        assert binary_labels.isel(piece=2).item() != -1
+
+
+class TestMultiDimensional:
+    """Tests for multi-dimensional cases."""
+
+    def test_multi_dimensional_pieces(self):
+        """Test with pieces that vary across another dimension."""
+        m = Model()
+        generators = ["gen1", "gen2"]
+        x = m.add_variables(coords=[generators], name="x")
+
+        # Different pieces per generator
+        starts = xr.DataArray(
+            [[0, 60], [0, 40]],
+            dims=["gen", "piece"],
+            coords={"gen": generators},
+        )
+        ends = xr.DataArray(
+            [[50, 100], [30, 70]],
+            dims=["gen", "piece"],
+            coords={"gen": generators},
+        )
+
+        m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+        # Variables should have both gen and piece dimensions
+        assert set(m.variables["dpwl0_binary"].dims) == {"gen", "piece"}
+        assert set(m.variables["dpwl0_delta"].dims) == {"gen", "piece"}
+
+
+class TestValidationErrors:
+    """Tests for input validation error handling."""
+
+    def test_invalid_expr_type(self):
+        """Test that invalid expr type raises ValueError."""
+        m = Model()
+
+        starts = xr.DataArray([0, 15], dims=["piece"])
+        ends = xr.DataArray([10, 25], dims=["piece"])
+
+        with pytest.raises(ValueError, match="must be a Variable, LinearExpression"):
+            m.add_discontinuous_piecewise_constraints(
+                "invalid", starts, ends, dim="piece"
+            )
+
+    def test_missing_dim_in_starts(self):
+        """Test error when dim is missing from piece_starts."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        starts = xr.DataArray([0, 15], dims=["other"])
+        ends = xr.DataArray([10, 25], dims=["piece"])
+
+        with pytest.raises(ValueError, match="piece_starts must have dimension"):
+            m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+    def test_missing_dim_in_ends(self):
+        """Test error when dim is missing from piece_ends."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        starts = xr.DataArray([0, 15], dims=["piece"])
+        ends = xr.DataArray([10, 25], dims=["other"])
+
+        with pytest.raises(ValueError, match="piece_ends must have dimension"):
+            m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+    def test_mismatched_dimensions(self):
+        """Test error when starts and ends have different dimensions."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        starts = xr.DataArray([[0, 15]], dims=["extra", "piece"])
+        ends = xr.DataArray([10, 25], dims=["piece"])
+
+        with pytest.raises(ValueError, match="must have same dimensions"):
+            m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+    def test_expression_support(self):
+        """Test that LinearExpression is supported as input."""
+        m = Model()
+        x = m.add_variables(name="x")
+        y = m.add_variables(name="y")
+
+        starts = xr.DataArray([0, 15], dims=["piece"])
+        ends = xr.DataArray([10, 25], dims=["piece"])
+
+        # Should not raise
+        m.add_discontinuous_piecewise_constraints(x + y, starts, ends, dim="piece")
+
+        assert "dpwl0_link" in m.constraints
+
+    def test_link_dim_not_in_pieces(self):
+        """Test error when link_dim is not in piece arrays."""
+        m = Model()
+        x = m.add_variables(name="x")
+        y = m.add_variables(name="y")
+
+        starts = xr.DataArray([0, 15], dims=["piece"])
+        ends = xr.DataArray([10, 25], dims=["piece"])
+
+        with pytest.raises(ValueError, match="not found in"):
+            m.add_discontinuous_piecewise_constraints(
+                {"x": x, "y": y}, starts, ends, link_dim="var", dim="piece"
+            )
+
+    def test_link_dim_coords_mismatch(self):
+        """Test error when link_dim coords don't match dict keys."""
+        m = Model()
+        x = m.add_variables(name="x")
+        y = m.add_variables(name="y")
+
+        starts = xr.DataArray(
+            [[0, 15], [0, 20]],
+            dims=["var", "piece"],
+            coords={"var": ["a", "b"]},  # doesn't match x, y
+        )
+        ends = xr.DataArray(
+            [[10, 25], [15, 30]],
+            dims=["var", "piece"],
+            coords={"var": ["a", "b"]},
+        )
+
+        with pytest.raises(ValueError, match="don't match expression keys"):
+            m.add_discontinuous_piecewise_constraints(
+                {"x": x, "y": y}, starts, ends, link_dim="var", dim="piece"
+            )
+
+
+class TestNameGeneration:
+    """Tests for automatic name generation."""
+
+    def test_auto_name_generation(self):
+        """Test that names are auto-generated with counter."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        starts = xr.DataArray([0, 15], dims=["piece"])
+        ends = xr.DataArray([10, 25], dims=["piece"])
+
+        m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+        m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+
+        assert "dpwl0_binary" in m.variables
+        assert "dpwl1_binary" in m.variables
+
+    def test_custom_name(self):
+        """Test that custom name parameter works."""
+        m = Model()
+        x = m.add_variables(name="x")
+
+        starts = xr.DataArray([0, 15], dims=["piece"])
+        ends = xr.DataArray([10, 25], dims=["piece"])
+
+        m.add_discontinuous_piecewise_constraints(
+            x, starts, ends, dim="piece", name="my_dpwl"
+        )
+
+        assert "my_dpwl_binary" in m.variables
+        assert "my_dpwl_delta" in m.variables
+        assert "my_dpwl_select" in m.constraints
+
+
+class TestSolverIntegration:
+    """Integration tests with actual solver (requires Gurobi, CPLEX, or HiGHS)."""
+
+    @pytest.mark.parametrize(
+        "solver,module",
+        [("gurobi", "gurobipy"), ("cplex", "cplex"), ("highs", "highspy")],
+    )
+    def test_solve_single_variable_gap(self, solver, module):
+        """Test solving with a gap - should find optimum in valid region."""
+        if solver not in available_solvers:
+            pytest.skip(f"{solver} not available")
+        pytest.importorskip(module)
+
+        m = Model()
+        x = m.add_variables(name="x", lower=-100, upper=100)
+
+        # Pieces: [0, 10] and [20, 30] with gap [10, 20]
+        # If we maximize x, should get x=30
+        starts = xr.DataArray([0.0, 20.0], dims=["piece"])
+        ends = xr.DataArray([10.0, 30.0], dims=["piece"])
+
+        m.add_discontinuous_piecewise_constraints(x, starts, ends, dim="piece")
+        m.add_objective(x, sense="max")
+
+        m.solve(solver_name=solver)
+
+        assert m.status == "ok"
+        assert np.isclose(m.solution["x"].item(), 30.0, atol=1e-5)
+
+    @pytest.mark.parametrize(
+        "solver,module",
+        [("gurobi", "gurobipy"), ("cplex", "cplex"), ("highs", "highspy")],
+    )
+    def test_solve_finds_correct_piece(self, solver, module):
+        """Test that solver correctly selects the optimal piece."""
+        if solver not in available_solvers:
+            pytest.skip(f"{solver} not available")
+        pytest.importorskip(module)
+
+        m = Model()
+        x = m.add_variables(name="x", lower=-100, upper=100)
+        y = m.add_variables(name="y", lower=-100, upper=100)
+
+        # x in [0, 10] -> y in [0, 5]
+        # x in [20, 30] -> y in [10, 20]
+        # Maximize y -> should pick second piece, y=20
+        starts = xr.DataArray(
+            [[0.0, 20.0], [0.0, 10.0]],
+            dims=["var", "piece"],
+            coords={"var": ["x", "y"]},
+        )
+        ends = xr.DataArray(
+            [[10.0, 30.0], [5.0, 20.0]],
+            dims=["var", "piece"],
+            coords={"var": ["x", "y"]},
+        )
+
+        m.add_discontinuous_piecewise_constraints(
+            {"x": x, "y": y}, starts, ends, link_dim="var", dim="piece"
+        )
+        m.add_objective(y, sense="max")
+
+        m.solve(solver_name=solver)
+
+        assert m.status == "ok"
+        assert np.isclose(m.solution["y"].item(), 20.0, atol=1e-5)
+        assert np.isclose(m.solution["x"].item(), 30.0, atol=1e-5)
+
+    @pytest.mark.parametrize(
+        "solver,module",
+        [("gurobi", "gurobipy"), ("cplex", "cplex"), ("highs", "highspy")],
+    )
+    def test_solve_step_function(self, solver, module):
+        """Test solving with a step function (discontinuity in y)."""
+        if solver not in available_solvers:
+            pytest.skip(f"{solver} not available")
+        pytest.importorskip(module)
+
+        m = Model()
+        x = m.add_variables(name="x", lower=0, upper=100)
+        y = m.add_variables(name="y", lower=0, upper=100)
+
+        # Step function: x in [0,50] -> y in [0,10], x in [50,100] -> y in [20,30]
+        # Note: x=50 can belong to either piece
+        starts = xr.DataArray(
+            [[0.0, 50.0], [0.0, 20.0]],
+            dims=["var", "piece"],
+            coords={"var": ["x", "y"]},
+        )
+        ends = xr.DataArray(
+            [[50.0, 100.0], [10.0, 30.0]],
+            dims=["var", "piece"],
+            coords={"var": ["x", "y"]},
+        )
+
+        m.add_discontinuous_piecewise_constraints(
+            {"x": x, "y": y}, starts, ends, link_dim="var", dim="piece"
+        )
+
+        # Maximize y -> should pick second piece
+        m.add_objective(y, sense="max")
+        m.solve(solver_name=solver)
+
+        assert m.status == "ok"
+        assert np.isclose(m.solution["y"].item(), 30.0, atol=1e-5)


### PR DESCRIPTION
## Summary

Add `add_discontinuous_piecewise_constraints()` using a binary formulation for piecewise linear optimization with gaps/discontinuities between pieces. Uses separate `piece_starts` and `piece_ends` arrays to define potentially non-contiguous intervals.

## Changes proposed in this Pull Request

### Implementation (`linopy/model.py`, `linopy/constants.py`)
- Add `add_discontinuous_piecewise_constraints()` public method with validation, mask computation, and binary formulation dispatch
- Add `_compute_dpwl_mask()` helper for NaN-aware mask computation
- Add constants: `DPWL_BINARY_SUFFIX`, `DPWL_DELTA_SUFFIX`, `DPWL_SELECT_SUFFIX`, `DPWL_DELTA_BOUND_SUFFIX`, `DPWL_LINK_SUFFIX`, `DEFAULT_PIECE_DIM`
- Separate `_dpwlCounter` for independent name generation

### Tests (`test/test_discontinuous_piecewise_constraints.py`)
- Add 8 test classes with 23 tests:
  - **TestBasicSingleVariable** (2 tests) — basic single variable, variable with coords
  - **TestDictOfVariables** (2 tests) — dict of variables, dict with additional coordinates
  - **TestAutoDetectLinkDim** (2 tests) — auto-detect success, auto-detect failure
  - **TestMasking** (4 tests) — NaN masking, partial NaN, explicit mask, skip_nan_check
  - **TestMultiDimensional** (1 test) — multi-dimensional pieces
  - **TestValidationErrors** (6 tests) — invalid expr, missing dim in starts/ends, mismatched dimensions, expression support, link_dim validation
  - **TestNameGeneration** (2 tests) — auto name generation, custom name
  - **TestSolverIntegration** (4 tests) — single variable, dict case, multi-generator, expression input

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.